### PR TITLE
[FQC-3] Modificando forma de listar usuários ativos e inativos através de filtros

### DIFF
--- a/banco.sql
+++ b/banco.sql
@@ -14,7 +14,8 @@ CREATE TABLE usuarios(
 	email varchar(200) not null unique,
 	senha text not null,
 	created_at timestamp default (now()),
-	updated_at timestamp default (now())
+	updated_at timestamp default (now()),
+	deleted_at timestamp
 );
 
 CREATE TRIGGER set_timestamp
@@ -24,7 +25,15 @@ EXECUTE PROCEDURE trigger_set_timestamp();
 
 CREATE TABLE  frequencias (
 	id serial primary key not null,
-	usuario_id int not null,
-	created_at timestamp default (now()),
-	constraint fk_usuario foreign key(usuario_id) references usuarios(id) on delete no action
+	data_atual timestamp default (now())
 );
+
+CREATE TABLE frequencia_usuario (
+	id serial primary key not null,
+	usuario_id int not null, 
+	frequencia_id int not null,
+	entrada timestamp default (now()),
+	saida timestamp,
+	constraint fk_usuario foreign key(usuario_id) references usuarios(id) on delete no action,
+	constraint fk_frequencia foreign key(frequencia_id) references frequencias(id) on delete no action
+)

--- a/config/database/dbpostgres.go
+++ b/config/database/dbpostgres.go
@@ -4,20 +4,20 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
-	//"os"
+	"os"
 
 	_ "github.com/lib/pq"
 )
 
-var host string = "localhost"
-var user string = "root"
-var password string = "root"
-var dbname string = "db_frequencia"
+var host string = os.Getenv("DB_HOST")
+var user string = os.Getenv("DB_USER")
+var password string = os.Getenv("DB_PASSWORD")
+var dbname string = os.Getenv("DB_NAME")
 const port = 5432
 
 func Conectar() *sql.DB {
 	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s " +
-		"password=%s dbname=%s sslmode=disable",
+		"password=%s dbname=%s sslmode=require",
 		host, port, user, password, dbname)
 
 	db, err := sql.Open("postgres", psqlInfo)

--- a/config/database/dbpostgres.go
+++ b/config/database/dbpostgres.go
@@ -9,6 +9,16 @@ import (
 	_ "github.com/lib/pq"
 )
 
+/*
+ *Para testes Localhost
+
+var host string = "localhost"
+var user string = "root"
+var password string = "root"
+var dbname string = "db_frequencia"
+const port = 5432
+*/
+
 var host string = os.Getenv("DB_HOST")
 var user string = os.Getenv("DB_USER")
 var password string = os.Getenv("DB_PASSWORD")
@@ -17,7 +27,7 @@ const port = 5432
 
 func Conectar() *sql.DB {
 	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s " +
-		"password=%s dbname=%s sslmode=require",
+		"password=%s dbname=%s sslmode=disable",
 		host, port, user, password, dbname)
 
 	db, err := sql.Open("postgres", psqlInfo)

--- a/domain/frequencia_usuario/model/model.go
+++ b/domain/frequencia_usuario/model/model.go
@@ -1,0 +1,25 @@
+package frequencia_usuario
+
+import "time"
+
+type ReqFrequenciaUsuario struct {
+	ID           *int       `json:"id"`
+	UsuarioID    *int       `json:"usuario_id"`
+	FrequenciaID *int       `json:"frequencia_id"`
+	Entrada      *time.Time `json:"entrada"`
+	Saida        *time.Time `json:"saida"`
+}
+
+type ResFrequenciaUsuario struct {
+	ID             *int       `json:"id"`
+	UsuarioID      *int       `json:"usuario_id"`
+	Nome           *string    `json:"nome"`
+	FrequenciaID   *int       `json:"frequencia_id"`
+	DataFrequencia *time.Time `json:"data_frequencia"`
+	Entrada        *time.Time `json:"entrada"`
+	Saida          *time.Time `json:"saida"`
+}
+
+type ListaUsuarioFrequencia struct {
+	Data []ResFrequenciaUsuario `json:"data"`
+}

--- a/domain/frequencia_usuario/usecase.go
+++ b/domain/frequencia_usuario/usecase.go
@@ -1,0 +1,31 @@
+package frequencia_usuario
+
+import (
+	"fmt"
+
+	"github.com/Brun0Nasc/Frequencias-Backend/config/database"
+	modelApresentacao "github.com/Brun0Nasc/Frequencias-Backend/domain/frequencia_usuario/model"
+	"github.com/Brun0Nasc/Frequencias-Backend/infra/frequencia_usuario"
+	"github.com/Brun0Nasc/Frequencias-Backend/infra/frequencias"
+)
+
+func NovaFrequenciaUsuario(req *modelApresentacao.ReqFrequenciaUsuario) (err error) {
+	db := database.Conectar()
+	defer db.Close()
+	frequenciaUsuarioRepo := frequencia_usuario.NovoRepo(db)
+	frequenciasRepo := frequencias.NovoRepo(db)
+
+	// * Pegando id da data de frequência mais atual
+	idFreq, err := frequenciasRepo.PegarFrequenciaMaisRecente()
+	if err != nil {
+		return
+	}
+
+	req.FrequenciaID = idFreq
+
+	err = frequenciaUsuarioRepo.NovaFrequenciaUsuario(req)
+	if err != nil {
+		return fmt.Errorf("frequencia de usuario nao registrada \nerr:" + err.Error())
+	}
+	return
+}

--- a/domain/frequencias/model/model.go
+++ b/domain/frequencias/model/model.go
@@ -4,9 +4,7 @@ import "time"
 
 type Frequencia struct {
 	ID        *int       `json:"id"`
-	UsuarioID *int       `json:"usuario_id"`
-	CreatedAt *time.Time `json:"created_at"`
-	Nome      *string    `json:"nome,omitempty"`
+	DataAtual *time.Time `json:"data_atual"`
 }
 
 type ListaFrequencias struct {

--- a/domain/frequencias/usecase.go
+++ b/domain/frequencias/usecase.go
@@ -4,30 +4,32 @@ import (
 	"fmt"
 
 	"github.com/Brun0Nasc/Frequencias-Backend/config/database"
-	modelApresentacao "github.com/Brun0Nasc/Frequencias-Backend/domain/frequencias/model"
 	"github.com/Brun0Nasc/Frequencias-Backend/infra/frequencias"
 )
 
-func NovaFrequencia(req *modelApresentacao.Frequencia) (err error) {
+func NovaFrequencia() (err error) {
 	db := database.Conectar()
 	defer db.Close()
 	frequenciasRepo := frequencias.NovoRepo(db)
 
-	err = frequenciasRepo.NovaFrequencia(req)
+	err = frequenciasRepo.NovaFrequencia()
 	if err != nil {
-		return fmt.Errorf("frequencia not added \nerr:" + err.Error())
+		return fmt.Errorf("frequencia não criada \nerr:" + err.Error())
 	}
 	return
 }
 
-func ListarFrequenciasUsuario(idUser *int64) (res *modelApresentacao.ListaFrequencias, err error) {
+func PegarFrequenciaMaisRecente() (res *int, err error) {
 	db := database.Conectar()
 	defer db.Close()
 	frequenciasRepo := frequencias.NovoRepo(db)
 
-	res, err = frequenciasRepo.ListarFrequenciasUsuario(idUser)
+	res, err = frequenciasRepo.PegarFrequenciaMaisRecente()
+
 	if err != nil {
-		return nil, fmt.Errorf("frequencia not list \nerr:" + err.Error())
+		return nil, fmt.Errorf("frequencia não listada \nerr:" + err.Error())
 	}
+	
 	return
 }
+

--- a/domain/usuarios/model/model.go
+++ b/domain/usuarios/model/model.go
@@ -10,6 +10,7 @@ type Usuario struct {
 	Senha     string     `json:"senha"`
 	CreatedAt *time.Time `json:"created_at"`
 	UpdatedAt *time.Time `json:"updated_at"`
+	RemovedAt *time.Time `json:"removed_at"`
 }
 
 type ListaUsuarios struct {

--- a/domain/usuarios/usecase.go
+++ b/domain/usuarios/usecase.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	"github.com/Brun0Nasc/Frequencias-Backend/config/database"
+	"github.com/Brun0Nasc/Frequencias-Backend/config/services"
 	modelApresentacao "github.com/Brun0Nasc/Frequencias-Backend/domain/usuarios/model"
 	"github.com/Brun0Nasc/Frequencias-Backend/infra/usuarios"
-	"github.com/Brun0Nasc/Frequencias-Backend/config/services"
+	"github.com/Brun0Nasc/Frequencias-Backend/utils"
 )
 
 func NovoUsuario(req *modelApresentacao.Usuario) (err error) {
@@ -16,21 +17,21 @@ func NovoUsuario(req *modelApresentacao.Usuario) (err error) {
 
 	req.Senha = services.SHAR256Encoder(req.Senha)
 	err = usuariosRepo.NovoUsuario(req)
-	if err != nil{
-		return fmt.Errorf("usuario nao adicionado // "+err.Error())
+	if err != nil {
+		return fmt.Errorf("usuario nao adicionado // " + err.Error())
 	}
 
 	return
 }
 
-func ListarUsuarios(order int) (res *modelApresentacao.ListaUsuarios, err error) {
+func ListarUsuarios(params *utils.RequestParams) (res *modelApresentacao.ListaUsuarios, err error) {
 	db := database.Conectar()
 	defer db.Close()
 	usuariosRepo := usuarios.NovoRepo(db)
 
-	res, err = usuariosRepo.ListarUsuarios(order)
+	res, err = usuariosRepo.ListarUsuarios(params)
 	if err != nil {
-		return nil, fmt.Errorf("usuarios nao listados // "+err.Error())
+		return nil, fmt.Errorf("usuarios nao listados // " + err.Error())
 	}
 
 	return
@@ -43,7 +44,7 @@ func InativarUsuario(id int) (err error) {
 
 	err = usuariosRepo.InativarUsuario(id)
 	if err != nil {
-		return fmt.Errorf("usuario nao inativado // "+err.Error())
+		return fmt.Errorf("usuario nao inativado // " + err.Error())
 	}
 
 	return

--- a/infra/frequencia_usuario/interface.go
+++ b/infra/frequencia_usuario/interface.go
@@ -1,0 +1,9 @@
+package frequencia_usuario
+
+import(
+	modelApresentacao "github.com/Brun0Nasc/Frequencias-Backend/domain/frequencia_usuario/model"
+)
+
+type IFrequenciaUsuario interface{
+	NovaFrequenciaUsuario(req *modelApresentacao.ReqFrequenciaUsuario) error
+}

--- a/infra/frequencia_usuario/model/model.go
+++ b/infra/frequencia_usuario/model/model.go
@@ -1,0 +1,11 @@
+package frequencia_usuario
+
+import "time"
+
+type FrequenciaUsuario struct {
+	ID           *int
+	UsuarioID    *int
+	FrequenciaID *int
+	Entrada      *time.Time
+	Saida        *time.Time
+}

--- a/infra/frequencia_usuario/postgres/data.go
+++ b/infra/frequencia_usuario/postgres/data.go
@@ -1,0 +1,70 @@
+package postgres
+
+import (
+	"database/sql"
+	"fmt"
+
+	sq "github.com/Masterminds/squirrel"
+	modelData "github.com/Brun0Nasc/Frequencias-Backend/infra/frequencia_usuario/model"
+)
+
+type DBFrequenciaUsuario struct {
+	DB *sql.DB
+}
+
+func (pg *DBFrequenciaUsuario) NovaFrequenciaUsuario(req *modelData.FrequenciaUsuario) (err error) {
+	sqlStatement, sqlValues, err := sq.
+		Insert("frequencia_usuario").
+		Columns("usuario_id, frequencia_id").
+		Values(req.UsuarioID, req.FrequenciaID).
+		PlaceholderFormat(sq.Dollar).
+		ToSql()
+	if err != nil {
+		return
+	}
+
+	_, err = pg.DB.Exec(sqlStatement, sqlValues...)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Frequencia adicionada")
+	return
+}
+
+/*func (pg *DBFrequencias) ListarFrequenciasUsuario(idUser *int64) (res *modelApresentacao.ListaFrequencias, err error) {
+	var frequencia = modelApresentacao.Frequencia{}
+
+	sqlStatement, sqlValues, err := sq.
+		Select("FR.*").
+		From("frequencias FR").
+		Join("usuarios US ON US.ID = FR.usuario_id").
+		Where(sq.Eq{
+			"US.id": idUser,
+		}).
+		PlaceholderFormat(sq.Dollar).
+		ToSql()
+
+	row, err := pg.DB.Query(sqlStatement, sqlValues...)
+	if err != nil {
+		return nil, err
+	}
+
+	res = &modelApresentacao.ListaFrequencias{
+		Dados: make([]modelApresentacao.Frequencia, 0),
+	}
+
+	for row.Next() {
+		if err := row.Scan(&frequencia.ID, &frequencia.UsuarioID, &frequencia.CreatedAt, &frequencia.Nome); err != nil {
+			if err == sql.ErrNoRows {
+				return res, nil
+			}
+			return nil, err
+		}
+
+		res.Dados = append(res.Dados, frequencia)
+	}
+
+	return
+}
+*/

--- a/infra/frequencia_usuario/repository.go
+++ b/infra/frequencia_usuario/repository.go
@@ -1,0 +1,26 @@
+package frequencia_usuario
+
+import (
+	"database/sql"
+
+	"github.com/Brun0Nasc/Frequencias-Backend/infra/frequencia_usuario/postgres"
+	modelApresentacao "github.com/Brun0Nasc/Frequencias-Backend/domain/frequencia_usuario/model"
+	modelData "github.com/Brun0Nasc/Frequencias-Backend/infra/frequencia_usuario/model"
+)
+
+type repositorio struct {
+	Data *postgres.DBFrequenciaUsuario
+}
+
+func novoRepo(novoDB *sql.DB) *repositorio {
+	return &repositorio{
+		Data: &postgres.DBFrequenciaUsuario{DB: novoDB},
+	}
+}
+
+func (r *repositorio) NovaFrequenciaUsuario(req *modelApresentacao.ReqFrequenciaUsuario) error {
+	return r.Data.NovaFrequenciaUsuario(&modelData.FrequenciaUsuario{
+		UsuarioID: req.UsuarioID,
+		FrequenciaID: req.FrequenciaID,
+	})
+}

--- a/infra/frequencia_usuario/service.go
+++ b/infra/frequencia_usuario/service.go
@@ -1,0 +1,9 @@
+package frequencia_usuario
+
+import (
+	"database/sql"
+) 
+
+func NovoRepo(DB *sql.DB) IFrequenciaUsuario {
+	return novoRepo(DB)
+}

--- a/infra/frequencias/interface.go
+++ b/infra/frequencias/interface.go
@@ -1,10 +1,6 @@
 package frequencias
 
-import (
-	modelApresentacao "github.com/Brun0Nasc/Frequencias-Backend/domain/frequencias/model"
-)
-
 type IFrequencia interface {
-	NovaFrequencia(req *modelApresentacao.Frequencia) error
-	ListarFrequenciasUsuario(idUser *int64) (*modelApresentacao.ListaFrequencias, error)
+	NovaFrequencia() error
+	PegarFrequenciaMaisRecente() (*int, error)
 }

--- a/infra/frequencias/model/model.go
+++ b/infra/frequencias/model/model.go
@@ -4,6 +4,5 @@ import "time"
 
 type Frequencia struct {
 	ID        *int
-	UsuarioID *int
-	CreatedAt *time.Time
+	DataAtual *time.Time
 }

--- a/infra/frequencias/repository.go
+++ b/infra/frequencias/repository.go
@@ -3,8 +3,6 @@ package frequencias
 import (
 	"database/sql"
 
-	modelApresentacao "github.com/Brun0Nasc/Frequencias-Backend/domain/frequencias/model"
-	modelData "github.com/Brun0Nasc/Frequencias-Backend/infra/frequencias/model"
 	"github.com/Brun0Nasc/Frequencias-Backend/infra/frequencias/postgres"
 )
 
@@ -18,12 +16,10 @@ func novoRepo(novoDB *sql.DB) *repositorio {
 	}
 }
 
-func (r *repositorio) NovaFrequencia(req *modelApresentacao.Frequencia) error {
-	return r.Data.NovaFrequencia(&modelData.Frequencia{
-		UsuarioID: req.UsuarioID,
-	})
+func (r *repositorio) NovaFrequencia() error {
+	return r.Data.NovaFrequencia()
 }
 
-func (r *repositorio) ListarFrequenciasUsuario(idUser *int64) (*modelApresentacao.ListaFrequencias, error) {
-	return r.Data.ListarFrequenciasUsuario(idUser)
+func (r *repositorio) PegarFrequenciaMaisRecente() (*int, error){
+	return r.Data.PegarFrequenciaMaisRecente()
 }

--- a/infra/usuarios/interface.go
+++ b/infra/usuarios/interface.go
@@ -1,12 +1,13 @@
 package usuarios
 
-import(
+import (
 	modelApresentacao "github.com/Brun0Nasc/Frequencias-Backend/domain/usuarios/model"
+	"github.com/Brun0Nasc/Frequencias-Backend/utils"
 )
 
 type IUsuario interface {
 	NovoUsuario(req *modelApresentacao.Usuario) error
-	ListarUsuarios(order int) (*modelApresentacao.ListaUsuarios, error)
+	ListarUsuarios(params *utils.RequestParams) (*modelApresentacao.ListaUsuarios, error)
 	//BuscarUsuario(id int) (*modelApresentacao.ReqUsuario, error)
 	InativarUsuario(id int) error
 	//AtualizarUsuario(id int, req *modelApresentacao.ReqUsuario) error

--- a/infra/usuarios/model/model.go
+++ b/infra/usuarios/model/model.go
@@ -10,4 +10,5 @@ type Usuario struct {
 	Senha     *string
 	CreatedAt *time.Time
 	UpdatedAt *time.Time
+	RemovedAt *time.Time
 }

--- a/infra/usuarios/postgres/data.go
+++ b/infra/usuarios/postgres/data.go
@@ -51,7 +51,7 @@ func (pg *DBUsuarios) ListarUsuarios(params *utils.RequestParams) (res *modelApr
 		Select("US.*").
 		From("usuarios US").
 		Where(sq.Eq{
-			"(US.removed_at IS NULL)": removido,
+			"(US.removed_at IS NOT NULL)": removido,
 		}).OrderBy(ordenador + " " + ordem).
 		PlaceholderFormat(sq.Dollar).
 		ToSql()
@@ -70,7 +70,7 @@ func (pg *DBUsuarios) ListarUsuarios(params *utils.RequestParams) (res *modelApr
 	}
 
 	for rows.Next() {
-		if err := rows.Scan(&usuario.ID, &usuario.Tipo, &usuario.Nome, &usuario.Email, &usuario.Senha, &usuario.CreatedAt, &usuario.UpdatedAt); err != nil {
+		if err := rows.Scan(&usuario.ID, &usuario.Tipo, &usuario.Nome, &usuario.Email, &usuario.Senha, &usuario.CreatedAt, &usuario.UpdatedAt, &usuario.RemovedAt); err != nil {
 			if err == sql.ErrNoRows {
 				return res, nil
 			}
@@ -84,7 +84,7 @@ func (pg *DBUsuarios) ListarUsuarios(params *utils.RequestParams) (res *modelApr
 }
 
 func (postgres *DBUsuarios) InativarUsuario(id int) error {
-	sqlStatement := `UPDATE usuarios SET tipo = 0 WHERE id = $1`
+	sqlStatement := `UPDATE usuarios SET removed_at = now() WHERE id = $1`
 
 	_, err := postgres.DB.Exec(sqlStatement, id)
 	if err != nil {

--- a/infra/usuarios/repository.go
+++ b/infra/usuarios/repository.go
@@ -2,9 +2,11 @@ package usuarios
 
 import (
 	"database/sql"
+
 	modelApresentacao "github.com/Brun0Nasc/Frequencias-Backend/domain/usuarios/model"
 	modelData "github.com/Brun0Nasc/Frequencias-Backend/infra/usuarios/model"
 	"github.com/Brun0Nasc/Frequencias-Backend/infra/usuarios/postgres"
+	"github.com/Brun0Nasc/Frequencias-Backend/utils"
 )
 
 type repositorio struct {
@@ -26,8 +28,8 @@ func (r *repositorio) NovoUsuario(req *modelApresentacao.Usuario) error {
 	})
 }
 
-func (r *repositorio) ListarUsuarios(order int) (*modelApresentacao.ListaUsuarios, error) {
-	return r.Data.ListarUsuarios(order)
+func (r *repositorio) ListarUsuarios(params *utils.RequestParams) (*modelApresentacao.ListaUsuarios, error) {
+	return r.Data.ListarUsuarios(params)
 }
 
 func (r *repositorio) InativarUsuario(id int) error {

--- a/utils/params.go
+++ b/utils/params.go
@@ -1,6 +1,11 @@
 package utils
 
-import "github.com/gin-gonic/gin"
+import (
+	"log"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
 
 type RequestParams struct {
 	Filters map[string][]string
@@ -8,12 +13,9 @@ type RequestParams struct {
 
 func ParseParams(c *gin.Context) (params *RequestParams) {
 	params = &RequestParams{Filters: make(map[string][]string, 0)}
-	
-	for i := range c.Params {
-		key := c.Params[i].Key
-		value := c.Params[i].Value
 
-		params.Filters[key] = append(params.Filters[key], value)
+	for key, value := range c.Request.URL.Query() {
+		params.Filters[key] = append(params.Filters[key], value...)
 	}
 
 	return
@@ -24,4 +26,18 @@ func (p *RequestParams) TemFiltro(key string) bool {
 		return true
 	}
 	return false
+}
+
+// TemFiltroBool verifica se um existe um valor para o filtro informado e retorna o valor do filtro booleano e um OK para informar se o filtro existe
+func (p *RequestParams) TemFiltroBool(key string) (bool, bool) {
+	if value1, ok := p.Filters[key]; ok {
+		value, err := strconv.ParseBool(value1[0])
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		return value, ok
+	}
+
+	return false, false
 }

--- a/webservice/frequencia_usuario/handler.go
+++ b/webservice/frequencia_usuario/handler.go
@@ -1,0 +1,37 @@
+package frequencia_usuario
+
+import (
+	"fmt"
+
+	"github.com/Brun0Nasc/Frequencias-Backend/domain/frequencia_usuario"
+	modelApresentacao "github.com/Brun0Nasc/Frequencias-Backend/domain/frequencia_usuario/model"
+	//"github.com/Brun0Nasc/Frequencias-Backend/utils"
+	"github.com/gin-gonic/gin"
+)
+
+func PegaJSON(c *gin.Context) *modelApresentacao.ReqFrequenciaUsuario {
+	var req = modelApresentacao.ReqFrequenciaUsuario{}
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(400, gin.H{
+			"message": "Could not create. Parameters were not passed correctly",
+			"err":     err.Error(),
+		})
+		return nil
+	}
+	return &req
+}
+
+func NovaFrequenciaUsuario(c *gin.Context) {
+	fmt.Println("Registrando Frequencia")
+
+	req := PegaJSON(c)
+
+	err := frequencia_usuario.NovaFrequenciaUsuario(req)
+
+	if err != nil {
+		c.JSON(400, gin.H{"err":err.Error()})
+		return
+	}
+
+	c.JSON(201, gin.H{"message":"Frequência registrada"})
+}

--- a/webservice/frequencia_usuario/rotas.go
+++ b/webservice/frequencia_usuario/rotas.go
@@ -1,0 +1,7 @@
+package frequencia_usuario
+
+import "github.com/gin-gonic/gin"
+
+func Router(r *gin.RouterGroup) {
+	r.POST("/", NovaFrequenciaUsuario)
+}

--- a/webservice/frequencias/handler.go
+++ b/webservice/frequencias/handler.go
@@ -1,17 +1,6 @@
 package frequencias
 
-import (
-	"fmt"
-	"net/http"
-	"strconv"
-
-	"github.com/Brun0Nasc/Frequencias-Backend/domain/frequencias"
-	modelApresentacao "github.com/Brun0Nasc/Frequencias-Backend/domain/frequencias/model"
-	"github.com/Brun0Nasc/Frequencias-Backend/utils"
-	"github.com/gin-gonic/gin"
-)
-
-func NovaFrequencia(c *gin.Context) {
+/*func NovaFrequencia(c *gin.Context) {
 	fmt.Println("Tentando cadastrar uma nova frequencia")
 	req := modelApresentacao.Frequencia{}
 	if err := c.BindJSON(&req); err != nil {
@@ -30,8 +19,9 @@ func NovaFrequencia(c *gin.Context) {
 
 	c.JSON(201, gin.H{"message": "Frequencia adicionada com sucesso!"})
 }
+*/
 
-func ListarFrequenciasUsuario(c *gin.Context) {
+/*func ListarFrequenciasUsuario(c *gin.Context) {
 	fmt.Println("Tentando buscar as frequencias de um usuário")
 	idUser, err := strconv.Atoi(c.Param("id"))
 
@@ -48,3 +38,4 @@ func ListarFrequenciasUsuario(c *gin.Context) {
 
 	c.JSON(http.StatusOK, frequencias)
 }
+*/

--- a/webservice/frequencias/rotas.go
+++ b/webservice/frequencias/rotas.go
@@ -1,8 +1,1 @@
 package frequencias
-
-import "github.com/gin-gonic/gin"
-
-func Router(r *gin.RouterGroup) {
-	r.POST("/", NovaFrequencia)
-	r.GET("/:id", ListarFrequenciasUsuario)
-}

--- a/webservice/main.go
+++ b/webservice/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/Brun0Nasc/Frequencias-Backend/config/server/middlewares"
-	"github.com/Brun0Nasc/Frequencias-Backend/webservice/frequencias"
+	"github.com/Brun0Nasc/Frequencias-Backend/webservice/frequencia_usuario"
 	"github.com/Brun0Nasc/Frequencias-Backend/webservice/login"
 	"github.com/Brun0Nasc/Frequencias-Backend/webservice/usuarios"
 	"github.com/gin-gonic/gin"
@@ -15,8 +15,8 @@ func main() {
 	r := gin.Default()
 	r.Use(middlewares.CORSMiddleware())
 
-	frequencias.Router(r.Group("frequencias", middlewares.Auth()))
-	usuarios.Router(r.Group("usuarios", middlewares.Auth()))
+	frequencia_usuario.Router(r.Group("frequencia"))
+	usuarios.Router(r.Group("usuarios"))
 	login.Router(r.Group("login")) //! nada de middlewares aqui
 
 	r.Run(":" + port)

--- a/webservice/main.go
+++ b/webservice/main.go
@@ -4,9 +4,9 @@ import (
 	"os"
 
 	"github.com/Brun0Nasc/Frequencias-Backend/config/server/middlewares"
-	"github.com/Brun0Nasc/Frequencias-Backend/webservice/frequencias"
 	"github.com/Brun0Nasc/Frequencias-Backend/webservice/login"
 	"github.com/Brun0Nasc/Frequencias-Backend/webservice/usuarios"
+	"github.com/Brun0Nasc/Frequencias-Backend/webservice/frequencia_usuario"
 	"github.com/gin-gonic/gin"
 )
 
@@ -15,8 +15,8 @@ func main() {
 	r := gin.Default()
 	r.Use(middlewares.CORSMiddleware())
 
-	frequencias.Router(r.Group("frequencias", middlewares.Auth()))
-	usuarios.Router(r.Group("usuarios", middlewares.Auth()))
+	usuarios.Router(r.Group("usuarios"))
+	frequencia_usuario.Router(r.Group("frequencia"))
 	login.Router(r.Group("login")) //! nada de middlewares aqui
 
 	r.Run(":" + port)

--- a/webservice/usuarios/handler.go
+++ b/webservice/usuarios/handler.go
@@ -4,51 +4,45 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/gin-gonic/gin"
-	modelApresentacao "github.com/Brun0Nasc/Frequencias-Backend/domain/usuarios/model"
 	"github.com/Brun0Nasc/Frequencias-Backend/domain/usuarios"
+	modelApresentacao "github.com/Brun0Nasc/Frequencias-Backend/domain/usuarios/model"
+	"github.com/Brun0Nasc/Frequencias-Backend/utils"
+	"github.com/gin-gonic/gin"
 )
 
 func pegaJSON(c *gin.Context) *modelApresentacao.Usuario {
 	var req = modelApresentacao.Usuario{}
 	if err := c.BindJSON(&req); err != nil {
 		c.JSON(400, gin.H{
-			"message":"Could not create. Parameters were not passed correctly",
-			"err":err.Error(),
+			"message": "Could not create. Parameters were not passed correctly",
+			"err":     err.Error(),
 		})
 		return nil
 	}
 	return &req
 }
 
-func novoUsuario(c *gin.Context){
+func novoUsuario(c *gin.Context) {
 	fmt.Println("Adicionando novo usuario")
 
 	req := pegaJSON(c)
 
 	err := usuarios.NovoUsuario(req)
 
-	if err != nil{
-		c.JSON(400, gin.H{"err":err.Error()})
+	if err != nil {
+		c.JSON(400, gin.H{"err": err.Error()})
 		return
 	}
 
-	c.JSON(201, gin.H{"message":"Usuário adicionado com sucesso!"})
+	c.JSON(201, gin.H{"message": "Usuário adicionado com sucesso!"})
 }
 
 func listarUsuarios(c *gin.Context) {
-	fmt.Println("Tentando listar usuarios")
-	order := c.Param("order")
+	params := utils.ParseParams(c)
 
-	intOrder, err := strconv.Atoi(order)
+	res, err := usuarios.ListarUsuarios(params)
 	if err != nil {
-		c.JSON(404, gin.H{"message":"Parâmetro passado de forma incorreta", "err":err.Error()})
-		return
-	}
-
-	res, err := usuarios.ListarUsuarios(intOrder)
-	if err != nil {
-		c.JSON(404, gin.H{"err":err.Error()})
+		c.JSON(404, gin.H{"err": err.Error()})
 		return
 	}
 
@@ -61,15 +55,15 @@ func inativarUsuario(c *gin.Context) {
 
 	intId, err := strconv.Atoi(id)
 	if err != nil {
-		c.JSON(404, gin.H{"err":err.Error()})
+		c.JSON(404, gin.H{"err": err.Error()})
 		return
 	}
 
 	err = usuarios.InativarUsuario(intId)
 	if err != nil {
-		c.JSON(400, gin.H{"err":err.Error()})
+		c.JSON(400, gin.H{"err": err.Error()})
 		return
 	}
 
-	c.JSON(200, gin.H{"message":"Cadastro inativado com sucesso"})
+	c.JSON(200, gin.H{"message": "Cadastro inativado com sucesso"})
 }

--- a/webservice/usuarios/rotas.go
+++ b/webservice/usuarios/rotas.go
@@ -4,6 +4,6 @@ import "github.com/gin-gonic/gin"
 
 func Router(r *gin.RouterGroup) {
 	r.POST("/", novoUsuario)
-	r.GET("/list_user/:order", listarUsuarios)
+	r.GET("/list_user", listarUsuarios)
 	r.DELETE("/inativar/:id", inativarUsuario)
 }


### PR DESCRIPTION
- Foi modificado a função de pegar os filtros informados na rota;
- A forma de registrar usuários ativos e inativos deve ser tratada através de um `removed_at::date` [assim qualquer usuário que possua o campo data preenchido é considerado como removido];
-  Foi adicionado uma nova função na utils `TemFiltroBool` que além de validar se o filtro existe ainda retorna o seu valor.

**Obs:** Para que essa funcionalidade funcione corretamente é necessário que seja modificado a forma de registrar usuários ativos/inativos. Nesse caso utilizando o campo do tipo date, caso o cliente possua o campo preenchido significa que ele foi removido e assim a gente consegue registrar duas informarções em uma: "data de remoção" e "removido (bool)"